### PR TITLE
Adjust kind name from Geolocation to Geolocation2 in order to fix iss…

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -86,7 +86,7 @@ enyo.kind({
 			{kind: "Windowing"},
 			{kind: "Subscriptions"},
 			{kind: "Notifications"},
-            {kind: "Geolocation"},
+            {kind: "Geolocation2"},
             {kind: "Camera"},
 			{kind: "FileApis"},
             {kind: "ResponsiveImg"},

--- a/source/views/Geolocation.js
+++ b/source/views/Geolocation.js
@@ -3,7 +3,7 @@
  */
 
 enyo.kind({
-	name: "Geolocation",
+	name: "Geolocation2",
 	layoutKind: "FittableRowsLayout",
 	components: [
 	    { kind: "onyx.Toolbar", layoutKind: "FittableColumnsLayout", components: [


### PR DESCRIPTION
…ues with newer Chrome

For some reason the newer versions of Chrome aren't liking the Geolocation kind name causing Testr app to not launch and give a white screen, so simply renaming it to Geolocation2 in order to work around this.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>