### PR TITLE
appinfo.json: Add permissions for mediacontroller

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -9,6 +9,6 @@
 	"icon": "icon.png",
 	"uiRevision": "2",
 	"trustLevel" : "trusted",
-	"requiredPermissions": ["appmanager.management", "database.management", "database.operation", "location-service.operation", "luna-sysmgr.operation", "systemsettings.query", "systemsettings.management"]
+	"requiredPermissions": ["appmanager.management", "database.management", "database.operation", "location-service.operation", "luna-sysmgr.operation",  "mediacontroller.query", "systemsettings.query", "systemsettings.management"]
 }
 


### PR DESCRIPTION
Fixes the following errors once the mediacontroller service is active:

Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"activateMediaSession"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"setMediaPlayStatus"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"setMediaPlayPosition"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"setMediaMetaData"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"setMediaPlayPosition"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"setMediaPlayStatus"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"unregisterMediaSession"} Service security groups don't allow method call.
Dec 22 08:57:23 pinephonepro com.webos.service.mediacontroller[1636]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.testr-1361","CATEGORY":"/","METHOD":"registerMediaSession"} Service security groups don't allow method call.
